### PR TITLE
Add padding-bottom to .bottom-menu for when no .footer is displayed

### DIFF
--- a/upstream/sass/style.sass
+++ b/upstream/sass/style.sass
@@ -97,6 +97,7 @@ hr
     justify-content: center
     align-items: center
     padding-top: 3rem
+    padding-bottom: 3rem
     text-align: center
 
 .footer
@@ -108,7 +109,7 @@ hr
     background-color: transparent
     position: relative
     bottom: 0
-    padding: 3rem 1rem
+    padding: 0rem 1rem 3rem 1rem
     font-family: $font
     font-size: 1rem
     line-height: 1em


### PR DESCRIPTION
Fixes #6

If no footer is configured, .bottom-menu will be the last element of the page. Without any padding-bottom .bottom-menu will be flush to the bottom of the page.
With this change the already existing padding between .bottom-menu and .footer is shifted from .footer to .bottom-menu.