### PR TITLE
Use get_url() on sam_menu to get full links incl. subfolders

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -25,7 +25,7 @@
                 {% if config.extra.sam_menu %}
                     {% for link in config.extra.sam_menu %}
                         <div class="big-link">
-                            <a href="{{ link.link }}">
+                            <a href="{{ get_url(path=link.link) }}">
                                 {{ link.text }}
                             </a>
                         </div>


### PR DESCRIPTION
With this PR, the `sam_menu` rendering template will use Zola's `get_url()` function in order to get a full link (including the `base_url` specified in `config.toml`). This is useful when your site destination is in a subfolder (for example `http://mydomain.tld/~mysubfolder`) and you don't want to prepend every link with `~mysubfolder`.

(Fixes #5)