### PR TITLE
Add authors taxonomy based on tags.

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -10,7 +10,8 @@ build_search_index = false
 check_external_links = true
 
 taxonomies = [
-    {name = "tags", rss = true}
+    {name = "tags", rss = true},
+    {name = "authors", rss = true}
 ]
 
 [extra]

--- a/content/posts/some-post.md
+++ b/content/posts/some-post.md
@@ -3,6 +3,7 @@ title = "Some Post"
 date = 2019-01-01
 [taxonomies]
 tags = ["some", "post"]
+authors = ["alice", "hyacinthe"] 
 +++
 
 This is a very simple to post.

--- a/content/posts/some-post.md
+++ b/content/posts/some-post.md
@@ -3,7 +3,7 @@ title = "Some Post"
 date = 2019-01-01
 [taxonomies]
 tags = ["some", "post"]
-authors = ["alice", "sam"] 
+authors = ["Alice", "Sam"] 
 +++
 
 This is a very simple to post.

--- a/content/posts/some-post.md
+++ b/content/posts/some-post.md
@@ -3,7 +3,7 @@ title = "Some Post"
 date = 2019-01-01
 [taxonomies]
 tags = ["some", "post"]
-authors = ["alice", "hyacinthe"] 
+authors = ["alice", "sam"] 
 +++
 
 This is a very simple to post.

--- a/content/posts/syntax-highlighting.md
+++ b/content/posts/syntax-highlighting.md
@@ -3,6 +3,7 @@ title = "Syntax Hightlighting"
 date = 2019-02-02
 [taxonomies]
 tags = ["syntax", "post"]
+authors = ["alice"]
 +++
 
 Here is some syntax hightlighting.

--- a/content/posts/syntax-highlighting.md
+++ b/content/posts/syntax-highlighting.md
@@ -3,7 +3,7 @@ title = "Syntax Hightlighting"
 date = 2019-02-02
 [taxonomies]
 tags = ["syntax", "post"]
-authors = ["alice"]
+authors = ["Alice"]
 +++
 
 Here is some syntax hightlighting.

--- a/templates/authors/list.html
+++ b/templates/authors/list.html
@@ -1,11 +1,11 @@
 {% extends "base.html" %}
 
 {% block htmltitle %}
-    authors - {{ config.title }}
+    Authors - {{ config.title }}
 {% endblock htmltitle %}
 
 {% block title %}
-    authors
+    Authors
 {% endblock title %}
 
 {% block content %}

--- a/templates/authors/list.html
+++ b/templates/authors/list.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+
+{% block htmltitle %}
+    authors - {{ config.title }}
+{% endblock htmltitle %}
+
+{% block title %}
+    authors
+{% endblock title %}
+
+{% block content %}
+<ul>
+    {% for author in terms %}
+        <li><a href="{{ author.permalink }}">{{ author.name }}</a></li>
+    {% endfor %}
+</ul>
+{% endblock content %}

--- a/templates/authors/single.html
+++ b/templates/authors/single.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+
+{% import "macros.html" as macros %}
+
+{% block htmltitle %}
+    {{ term.name }} - {{ config.title }}
+{% endblock htmltitle %}
+
+{% block title %}
+    {{ term.name }}
+{% endblock title %}
+
+{% block content %}
+<ul>
+    {% for page in term.pages %}
+        <li>
+            {% if page.date %}
+                {{ macros::format_date(date=page.date) }} -- 
+            {% endif %}
+            <a href="{{ page.permalink }}">{{ macros::title_or_last(component=page, offset=0) }}</a>
+        </li>
+    {% endfor %}
+</ul>
+{% endblock content %}

--- a/templates/page.html
+++ b/templates/page.html
@@ -32,7 +32,7 @@
         {% endif %}
         {% if page.taxonomies.tags %}
             <div class="tag-container">
-                Tags : 
+                Tags :&nbsp;
                 {% for tag in page.taxonomies.tags %}
                     <span class="tag">
                         <a href="{{ get_taxonomy_url(kind='tags', name=tag) }}">
@@ -44,7 +44,7 @@
         {% endif %}
         {% if page.taxonomies.authors %}
             <div class="tag-container">
-                Authors :
+                Authors :&nbsp;
                 {% for author in page.taxonomies.authors %}
                     <span class="tag">
                         <a href="{{ get_taxonomy_url(kind='authors', name=author) }}">

--- a/templates/page.html
+++ b/templates/page.html
@@ -32,10 +32,23 @@
         {% endif %}
         {% if page.taxonomies.tags %}
             <div class="tag-container">
+                Tags : 
                 {% for tag in page.taxonomies.tags %}
                     <span class="tag">
                         <a href="{{ get_taxonomy_url(kind='tags', name=tag) }}">
                             {{ tag }}
+                        </a>
+                    </span>
+                {% endfor %}
+            </div>
+        {% endif %}
+        {% if page.taxonomies.authors %}
+            <div class="tag-container">
+                Authors :
+                {% for author in page.taxonomies.authors %}
+                    <span class="tag">
+                        <a href="{{ get_taxonomy_url(kind='authors', name=author) }}">
+                            {{ author }}
                         </a>
                     </span>
                 {% endfor %}


### PR DESCRIPTION
On a multi-authors website, could be interesting to have an authors section in posts. This is a minimal work to have this section using the tags div.