### PR TITLE
Add a head block so people can easily extends the theme

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -3,6 +3,7 @@
 <!DOCTYPE html>
 <html>
     <head>
+        {% block head %}
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="chrome=1">
         <meta name="HandheldFriendly" content="True">
@@ -18,6 +19,7 @@
         {% if config.generate_rss %}
             <link rel="alternate" type="application/rss+xml" title="RSS" href="{{ get_url(path='rss.xml') }}">
         {% endif %}
+        {% enblock head %}
     </head>
     <body>
         {% block body %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -19,7 +19,7 @@
         {% if config.generate_rss %}
             <link rel="alternate" type="application/rss+xml" title="RSS" href="{{ get_url(path='rss.xml') }}">
         {% endif %}
-        {% enblock head %}
+        {% endblock head %}
     </head>
     <body>
         {% block body %}


### PR DESCRIPTION
This would allow to extends the `head` parts of your theme easily.
Here is an example of `index.html` file we could put in `templates/`:
```
{% extends "sam/templates/index.html" %}
{% block head %}
        {{ super() }}
        <link rel="stylesheet" href="fenced_code_tab.css">
{% endblock head %}
```