### PR TITLE
fix: correct generate_feed variable

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -15,7 +15,7 @@
 
         <title>{% block htmltitle %}{{ config.title }}{% endblock htmltitle %}</title>
 
-        {% if config.generate_rss %}
+        {% if config.generate_feed %}
             <link rel="alternate" type="application/rss+xml" title="RSS" href="{{ get_url(path='rss.xml') }}">
         {% endif %}
     </head>


### PR DESCRIPTION
Based on https://www.getzola.org/documentation/templates/feeds/, correct variable name is `generate_feed`. `generate_rss` doesn't exist and adding it to `config.toml.` doesn't do anything. When changed to `generate_feed`, `<link>` tag is created as expected.